### PR TITLE
fix(readme) make markdown valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Universal React (& Redux) base
 
-##What is it
+## What is it
 This is a basic boilerplate to help you get started with React & Redux. What you need to know about it:
 - The main focus of this base is to demonstrate how to start a Universal React & Redux app in a simple and concise way, using just a minimum amount of baggage
 - It will show you how to fetch a component's data from an API server and ultimately construct and send the final HTML to the client, *after* all the required data is fetched
 - It assumes you have at least a basic understanding of how [React](https://facebook.github.io/react/docs/tutorial.html), [Redux](https://egghead.io/series/getting-started-with-redux) ~~and [Immutable data structures](http://facebook.github.io/immutable-js/)~~ work
 
-##What's left to do
+## What's left to do
 - [ ] Add user authentication (that's what the form is there for) and restrict access to specific routes/components
 - [ ] Add [ImmutableJS](https://github.com/facebook/immutable-js/)
 - [ ] Don't dispatch the action in componentDidMount if the data has already been fetched from server-side rendering
 - [ ] Further improve the codebase (feel free to make suggestions, PRs etc)
 
-##The stack
+## The stack
 - [x] Express & json-server
 - [x] Webpack
 - [x] React
@@ -21,7 +21,7 @@ This is a basic boilerplate to help you get started with React & Redux. What you
 - [x] PostCSS, CSS Modules & cssnext
 - [ ] ImmutableJS
 
-##Installation
+## Installation
 *Note: The current build hasn't been tested on Windows.*
 
 Clone this [repository](https://github.com/vslio/universal-react-base):
@@ -66,7 +66,7 @@ npm start
 
 The project is accessible on `http://localhost:3000` and the API server on `http://localhost3001`.
 
-##Structure
+## Structure
     .
     ├── db                      # DB file for the mock API (used by json-server)
     ├── dist                    # Final asset bundles (JS, images etc)
@@ -86,13 +86,13 @@ The project is accessible on `http://localhost:3000` and the API server on `http
                 └── modules     # Common styles that can be composed (or @extend-ed in SASS-land) in components
 
 
-##Useful things to know
-###Style Guide
+## Useful things to know
+### Style Guide
 I have opted for [StandardJS](https://github.com/feross/standard), because it's more in line with how I've been coding all along. Feel free to use whatever style guide you prefer ([Airbnb](https://github.com/airbnb/javascript) is one of the most popular ones).
 
-###Components
+### Components
 Some Components are defined as `Stateless Functions` instead of classes:
-```
+```js
 import React from 'react'
 import style from './home.css'
 
@@ -106,7 +106,7 @@ export default () => (
 This is the recommended option when the component we're creating does not need to retain internal state and doesn't have any of the lifecycle methods. For more information check [this section of the React documentation](https://facebook.github.io/react/docs/reusable-components.html#stateless-functions).
 Caveat: Hot reloading doesn't work with stateless functions. There is no support at this stage, [but it could happen](https://github.com/gaearon/babel-plugin-react-transform/issues/57). This is the case because I am using the experimental [react-transform-hmr](https://github.com/gaearon/react-transform-hmr). This will likely be removed in the future, in favour of Webpack's native HMR.
 
-###CSS
+### CSS
 Using [PostCSS](http://postcss.org), [CSS Modules](http://glenmaddern.com/articles/css-modules) and [cssnext](http://cssnext.io).
 Despite being a big fan of SASS and global CSS in general, I decided to give CSS Modules a go. There are a few quirks to overcome and you need to 'retrain' your brain to do things in a different way, but, ultimately, I believe it's the way to go for React projects. Please, make sure to read the article I linked above regarding CSS Modules. It's probably the most thorough you will find and it outlines most of the pros and cons of using them.
 


### PR DESCRIPTION
GitHub changed their rendering a few weeks ago, and headers now need a space after the `#`. Also added a language to the code block